### PR TITLE
Cleanup in tutotial.rst

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -190,7 +190,7 @@ as a tag retrieval rule:
 
 .. code-block:: yaml
 
-		tags_rules:
+		tag_rules:
 		  - name: day
 		    pattern: "(?i)day([0-9]+)_"
 		    length: 2
@@ -206,7 +206,7 @@ it with *G*. Putting these together as a rule:
 
 .. code-block:: yaml
 
-		tags_rules:
+		tag_rules:
 		  - name: mice
 		    pattern: "_G?([0-9]+)_"
 		    prepend: G
@@ -217,7 +217,7 @@ similarly, let ``extension`` be *.npy*.
 
 .. code-block:: yaml
 
-		tags_rules:
+		tag_rules:
 		  - name: imaging
 		    value: calcium
 		  - name: extension
@@ -229,13 +229,13 @@ Putting these together, we get our organization rules config:
 
 		source: "/path/to/unorganized/data"
 		destination: "/path/to/store/organized/data"
-		pattern: "*.npy"
+		pattern: ".*.npy"
 		tags_rules:
 		  - name: day
 		    pattern: "(?i)day([0-9]+)_"
 		    length: 2
 		    iffy_prefix: 0
-		    default: 1
+		    default: 01
 		  - name: mice
 		    pattern: "_G?([0-9]+)_"
 		    prepend: G


### PR DESCRIPTION
Clean PR request for tutorial.rst
1 tags_rules are replace to tag_rules,
2 under rules:
    default : 01 instead of default: 1,
    pattern .*.npy instead of *.np

**Description**

Summary of the change and which issue is fixed.

Fixes # (issue)

**Type of change**

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [*] Documentation update

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [*] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Existing tests pass with my changes
